### PR TITLE
Improve code and add static analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go:
   - "1.10"
 
 script:
+  - make analysis
   - make test
   - make bench
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ fmt:
 bench:
 	- go test ./... -bench .
 	
+	
 analysis:
+	go get golang.org/x/lint/golint
 	go get honnef.co/go/tools/cmd/megacheck
 	megacheck ./...
+	golint ./...

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: analysis test
+
 test:
 	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
@@ -6,3 +8,7 @@ fmt:
 	
 bench:
 	- go test ./... -bench .
+	
+analysis:
+	go get honnef.co/go/tools/cmd/megacheck
+	megacheck ./...

--- a/assert/equal.go
+++ b/assert/equal.go
@@ -8,6 +8,9 @@ import (
 
 var ε = math.Nextafter(1, 2) - 1
 
+// EqualStrings compares the two strings for equality.
+// If they are not equal t.Fatal is called using the details parameter.
+// The details parameter can be a single string of a format string + parameters.
 func EqualStrings(t *testing.T, want string, got string, details ...interface{}) {
 	t.Helper()
 	if want != got {
@@ -16,6 +19,9 @@ func EqualStrings(t *testing.T, want string, got string, details ...interface{})
 	}
 }
 
+// EqualInts compares the two ints for equality.
+// If they are not equal t.Fatal is called using the details parameter.
+// The details parameter can be a single string of a format string + parameters.
 func EqualInts(t *testing.T, want int, got int, details ...interface{}) {
 	t.Helper()
 	if want != got {
@@ -24,6 +30,9 @@ func EqualInts(t *testing.T, want int, got int, details ...interface{}) {
 	}
 }
 
+// EqualFloats compares the two floats for equality.
+// If they are not equal t.Fatal is called using the details parameter.
+// The details parameter can be a single string of a format string + parameters.
 func EqualFloats(
 	t *testing.T, want, got float64, details ...interface{},
 ) {
@@ -36,6 +45,10 @@ func EqualFloats(
 	}
 }
 
+// EqualErrs compares if two errors have the same error description (by calling .Error()).
+// If they are not equal t.Fatal is called using the details parameter.
+// Both errors can't be nil.
+// The details parameter can be a single string of a format string + parameters.
 func EqualErrs(
 	t *testing.T, want, got error, details ...interface{},
 ) {

--- a/assert/error.go
+++ b/assert/error.go
@@ -2,6 +2,8 @@ package assert
 
 import "testing"
 
+// NoError will call Fatal if the given error is not nil.
+// The details parameter can be a single string of a format string + parameters.
 func NoError(t *testing.T, err error, details ...interface{}) {
 	t.Helper()
 	if err != nil {
@@ -9,6 +11,8 @@ func NoError(t *testing.T, err error, details ...interface{}) {
 	}
 }
 
+// Error will call Fatal if the given error is nil.
+// The details parameter can be a single string of a format string + parameters.
 func Error(t *testing.T, err error, details ...interface{}) {
 	if err == nil {
 		t.Fatalf("expected error, got nil.%s", errordetails(details...))

--- a/muxer/muxer_test.go
+++ b/muxer/muxer_test.go
@@ -134,7 +134,7 @@ func TestMuxDirectionedChannels(t *testing.T) {
 
 	assert.NoError(t, muxer.Do(sinkd, sourced))
 
-	v, _ := <-sink
+	v := <-sink
 	assert.EqualStrings(t, expectedVal, v)
 }
 

--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -1,4 +1,4 @@
-// Package sempaphore provides a simple implementation of a semaphore (hence the name, duh).
+// Package semaphore provides a simple implementation of a semaphore (hence the name, duh).
 // Semaphores may be usefull to enforce a upper bound on how much
 // concurrent units executes some algorithm that is very heavy on memory and/or CPU.
 //

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -1,19 +1,20 @@
 package semaphore_test
 
 import (
-	"fmt"
-	"time"
-	"testing"
 	"context"
+	"errors"
+	"fmt"
 	"runtime"
-	
+	"testing"
+	"time"
+
 	"github.com/madlambda/spells/assert"
 	"github.com/madlambda/spells/semaphore"
 )
 
 func TestSemaphore(t *testing.T) {
-	sizes := []uint{ 1, 2, 3, 1000 }
-	
+	sizes := []uint{1, 2, 3, 1000}
+
 	for _, size := range sizes {
 		t.Run(fmt.Sprintf("Size%d", size), func(t *testing.T) {
 			s := semaphore.New(size)
@@ -24,12 +25,12 @@ func TestSemaphore(t *testing.T) {
 			testSemaphore(t, s, size)
 		})
 	}
-	
+
 }
 
 func TestSemaphoreSizeCantBeZero(t *testing.T) {
 	defer assertPanic(t, "expected panic creating semaphore with size 0")
-    semaphore.New(0)
+	semaphore.New(0)
 }
 
 func TestSemaphoreCantReleaseSameAcquireTwice(t *testing.T) {
@@ -37,7 +38,7 @@ func TestSemaphoreCantReleaseSameAcquireTwice(t *testing.T) {
 
 	s := semaphore.New(1)
 	release, err := s.Acquire(context.Background())
-	
+
 	assert.NoError(t, err)
 	release()
 	release()
@@ -47,46 +48,51 @@ func assertPanic(t *testing.T, errmsg string) {
 	r := recover()
 	if r == nil {
 		t.Error(errmsg)
-    }
-    if _, ok := r.(runtime.Error); ok {
-    	t.Errorf("Unexpected runtime error[%s]", r)
-    }
+	}
+	if _, ok := r.(runtime.Error); ok {
+		t.Errorf("Unexpected runtime error[%s]", r)
+	}
 }
 
 func testSemaphore(t *testing.T, s semaphore.S, size uint) {
-	
+
 	releases := []semaphore.Release{}
-	
+
 	for i := uint(0); i < size; i++ {
 		release, err := s.Acquire(context.Background())
 		assert.NoError(t, err)
 		releases = append(releases, release)
 	}
-	
-	timeoutWorked := make(chan struct{})
+
+	timeoutWorked := make(chan error)
 	go func() {
 		timeout := 100 * time.Millisecond
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
-		
+
 		_, err := s.Acquire(ctx)
-		assert.Error(t, err)
-		if ctx.Err() != context.DeadlineExceeded {
-			t.Fatalf("expected deadline exceeded on acquire context, got[%s]", ctx.Err())
+		if err == nil {
+			timeoutWorked <- errors.New("expected timeout error, got none")
+			return
 		}
-		timeoutWorked <- struct{}{}
+		if ctx.Err() != context.DeadlineExceeded {
+			timeoutWorked <- fmt.Errorf("expected deadline exceeded on acquire context, got[%s]", ctx.Err())
+			return
+		}
+		timeoutWorked <- nil
 	}()
-	
-	<-timeoutWorked
-	
+
+	err := <-timeoutWorked
+	assert.NoError(t, err)
+
 	releases[0]()
 	releases = releases[1:]
-	
+
 	r, err := s.Acquire(context.Background())
 	assert.NoError(t, err)
-	
+
 	releases = append(releases, r)
-	
+
 	for _, release := range releases {
 		release()
 	}


### PR DESCRIPTION
One of the problems found by static analysis is calling Fatalf on a different goroutine..I was not even aware that this could be a problem but it makes sense since it will call runtime.Goexit on the running goroutine:

https://golang.org/pkg/testing/#T.FailNow