### PR TITLE
Add iotest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 coverage.txt
+
+// Files created by Go profiler
 profilling
-iotest.test
+*.test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage.txt
+profilling

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage.txt
 profilling
+iotest.test

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ fmt:
 bench:
 	go test -bench=. ./...
 
-bench/%:
-	mkdir -p profilling
-	go test -bench=. -memprofile="profilling/${*}-memory.p" "./${*}"
+bench/memory/%:
+	@mkdir -p profilling
+	go test -bench=. -benchmem -memprofile="profilling/${*}-memory.p" "./${*}"
 
 lint:
 	@docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:v$(golangci_lint_version)  golangci-lint run ./...

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ fmt:
 	gofmt -s -w .
 
 bench:
-	go test ./... -bench .
+	go test -bench=. ./...
+
+bench/%:
+	mkdir -p profilling
+	go test -bench=. -memprofile="profilling/${*}-memory.p" "./${*}"
 
 lint:
 	@docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:v$(golangci_lint_version)  golangci-lint run ./...

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ golangci_lint_version=1.21.0
 all: analysis test
 
 test:
-	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+	go test -race -timeout 10s -coverprofile=coverage.txt -covermode=atomic ./...
+
+test/%:
+	go test -race -timeout 10s -coverprofile=coverage.txt -covermode=atomic -run="${*}" ./...
 
 fmt:
 	gofmt -s -w .

--- a/assert/error.go
+++ b/assert/error.go
@@ -14,6 +14,7 @@ func NoError(t *testing.T, err error, details ...interface{}) {
 // Error will call Fatal if the given error is nil.
 // The details parameter can be a single string of a format string + parameters.
 func Error(t *testing.T, err error, details ...interface{}) {
+	t.Helper()
 	if err == nil {
 		t.Fatalf("expected error, got nil.%s", errordetails(details...))
 	}

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -4,6 +4,7 @@
 package iotest
 
 import (
+	"fmt"
 	"io"
 )
 
@@ -35,21 +36,27 @@ func NewRepeatReader(r io.Reader, n int) *RepeatReader {
 }
 
 func (r *RepeatReader) Read(d []byte) (int, error) {
+	if r.repeatCount == 0 {
+		if r.err == nil {
+			r.err = io.EOF
+		}
+		return 0, r.err
+	}
+
 	if r.err == nil {
 		n, err := r.reader.Read(d)
 		r.err = err
 		r.readData = append(r.readData, d[:n]...)
-		if err == io.EOF && r.repeatCount > 0 {
+
+		fmt.Println(err)
+		if err == io.EOF {
+			r.repeatCount -= 1
 			return n, nil
 		}
 		return n, err
 	}
 
 	if r.err != io.EOF {
-		return 0, r.err
-	}
-
-	if r.repeatCount == 0 {
 		return 0, r.err
 	}
 

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -4,7 +4,6 @@
 package iotest
 
 import (
-	"errors"
 	"io"
 )
 
@@ -16,14 +15,6 @@ type RepeaterReader struct {
 	readIndex   int
 	err         error
 	repeatCount uint
-}
-
-// BrokenReader is an io.Reader that always fails
-// It is safe to use a BrokenReader concurrently.
-type BrokenReader struct {
-	// Err is the error you want to inject on Read calls.
-	// If it is nil a default error is going to be returned on the Read call.
-	Err error
 }
 
 // NewRepeater creates RepeaterReader that will repeat the
@@ -70,11 +61,4 @@ func (r *RepeaterReader) Read(d []byte) (int, error) {
 		r.repeatCount -= 1
 	}
 	return n, nil
-}
-
-func (r BrokenReader) Read(d []byte) (int, error) {
-	if r.Err == nil {
-		r.Err = errors.New("BrokenReaderError")
-	}
-	return 0, r.Err
 }

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -7,15 +7,21 @@ import "io"
 
 // RepeaterReader is an io.Reader that repeats a given io.Reader
 type RepeaterReader struct {
+	reader      io.Reader
+	repeatCount uint
 }
 
 // NewRepeater creates RepeaterReader that will repeat the
-// given reader "n" times. If n is 0 it will repeat the
-// given stream forever (and infinite stream).
+// given reader "n" times. If n=0 it won't repeat it and will only
+// provide the contents of the given reader once. If n=1 it will repeat
+// once, duplicating the input.
 func NewRepeater(r io.Reader, n uint) *RepeaterReader {
-	return nil
+	return &RepeaterReader{
+		reader:      r,
+		repeatCount: n,
+	}
 }
 
 func (r *RepeaterReader) Read(d []byte) (int, error) {
-	return 0, nil
+	return r.reader.Read(d)
 }

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -14,7 +14,7 @@ type RepeaterReader struct {
 	readData    []byte
 	readIndex   int
 	err         error
-	repeatCount uint
+	repeatCount int
 }
 
 // NewRepeater creates RepeaterReader that will repeat the
@@ -27,7 +27,7 @@ type RepeaterReader struct {
 //
 // It can be a cheap way to generate gigantic inputs by repeating a very
 // small input.
-func NewRepeater(r io.Reader, n uint) *RepeaterReader {
+func NewRepeater(r io.Reader, n int) *RepeaterReader {
 	return &RepeaterReader{
 		reader:      r,
 		repeatCount: n,

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -18,15 +18,19 @@ type RepeatReader struct {
 }
 
 // NewRepeatReader creates RepeatReader that will repeat the
-// given reader "n" times. If n=0 it won't repeat it and will only
-// provide the contents of the given reader once. If n=1 it will repeat
-// once, duplicating the input.
+// given io.Reader "n" times.
+//
+// If n=0 it won't provide any data and will return an io.EOF immediately (empty stream).
+// If n=1 it will repeat once, just like reading the original stream.
+// If n=2 it will repeat the underlying stream twice, doubling it.
 //
 // It will use O(N) memory where N is the size of the contents read from
 // the given reader (all contents are kept in memory and looped over).
 //
 // It can be a cheap way to generate gigantic inputs by repeating a very
-// small input.
+// small input (it will only use O(N) where N= small input size).
+//
+// It is a severe programming error to pass a negative count, resulting in a panic.
 func NewRepeatReader(r io.Reader, n int) *RepeatReader {
 	return &RepeatReader{
 		reader:      r,

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -24,7 +24,7 @@ type RepeatReader struct {
 type RepeatReaderError string
 
 const (
-	RepeatReaderInvalidCount RepeatReaderError = "Repeat reader count must be >= 0"
+	RepeatReaderInvalidCountErr RepeatReaderError = "Repeat reader count must be >= 0"
 )
 
 // NewRepeatReader creates RepeatReader that will repeat the
@@ -43,7 +43,7 @@ const (
 // It is a severe programming error to pass a negative count, resulting in a panic.
 func NewRepeatReader(r io.Reader, n int) *RepeatReader {
 	if n < 0 {
-		panic(fmt.Errorf("%w : count is %d", RepeatReaderInvalidCount, n))
+		panic(fmt.Errorf("%w : count is %d", RepeatReaderInvalidCountErr, n))
 	}
 	return &RepeatReader{
 		reader:      r,
@@ -51,6 +51,8 @@ func NewRepeatReader(r io.Reader, n int) *RepeatReader {
 	}
 }
 
+// Read implements the same behavior of the underlying io.Reader + repeating
+// semantics.
 func (r *RepeatReader) Read(d []byte) (int, error) {
 	if r.repeatCount == 0 {
 		if r.err == nil {

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -4,7 +4,6 @@
 package iotest
 
 import (
-	"fmt"
 	"io"
 )
 
@@ -48,7 +47,6 @@ func (r *RepeatReader) Read(d []byte) (int, error) {
 		r.err = err
 		r.readData = append(r.readData, d[:n]...)
 
-		fmt.Println(err)
 		if err == io.EOF {
 			r.repeatCount -= 1
 			return n, nil

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -9,6 +9,7 @@ import (
 )
 
 // RepeaterReader is an io.Reader that repeats a given io.Reader
+// It is NOT safe to use a RepeaterReader concurrently.
 type RepeaterReader struct {
 	reader      io.Reader
 	readData    []byte
@@ -18,6 +19,7 @@ type RepeaterReader struct {
 }
 
 // BrokenReader is an io.Reader that always fails
+// It is safe to use a BrokenReader concurrently.
 type BrokenReader struct {
 	// Err is the error you want to inject on Read calls.
 	// If it is nil a default error is going to be returned on the Read call.
@@ -28,6 +30,12 @@ type BrokenReader struct {
 // given reader "n" times. If n=0 it won't repeat it and will only
 // provide the contents of the given reader once. If n=1 it will repeat
 // once, duplicating the input.
+//
+// It will use O(N) memory where N is the size of the contents read from
+// the given reader (all contents are kept in memory and looped over).
+//
+// It can be a cheap way to generate gigantic inputs by repeating a very
+// small input.
 func NewRepeater(r io.Reader, n uint) *RepeaterReader {
 	return &RepeaterReader{
 		reader:      r,

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -55,10 +55,7 @@ func NewRepeatReader(r io.Reader, n int) *RepeatReader {
 // semantics.
 func (r *RepeatReader) Read(d []byte) (int, error) {
 	if r.repeatCount == 0 {
-		if r.err == nil {
-			r.err = io.EOF
-		}
-		return 0, r.err
+		return 0, io.EOF
 	}
 
 	if r.err == nil {

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -4,6 +4,7 @@
 package iotest
 
 import (
+	"fmt"
 	"io"
 )
 
@@ -16,6 +17,15 @@ type RepeatReader struct {
 	err         error
 	repeatCount int
 }
+
+// RepeatReaderError is an enumeration of errors that are part of
+// RepeatReader interface. The sentinel errors are wrapped
+// with dynamic context, so always check using errors.Is.
+type RepeatReaderError string
+
+const (
+	RepeatReaderInvalidCount RepeatReaderError = "Repeat reader count must be >= 0"
+)
 
 // NewRepeatReader creates RepeatReader that will repeat the
 // given io.Reader "n" times.
@@ -32,6 +42,9 @@ type RepeatReader struct {
 //
 // It is a severe programming error to pass a negative count, resulting in a panic.
 func NewRepeatReader(r io.Reader, n int) *RepeatReader {
+	if n < 0 {
+		panic(fmt.Errorf("%w : count is %d", RepeatReaderInvalidCount, n))
+	}
 	return &RepeatReader{
 		reader:      r,
 		repeatCount: n,
@@ -70,4 +83,8 @@ func (r *RepeatReader) Read(d []byte) (int, error) {
 		r.repeatCount -= 1
 	}
 	return n, nil
+}
+
+func (r RepeatReaderError) Error() string {
+	return string(r)
 }

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -7,9 +7,9 @@ import (
 	"io"
 )
 
-// RepeaterReader is an io.Reader that repeats a given io.Reader
-// It is NOT safe to use a RepeaterReader concurrently.
-type RepeaterReader struct {
+// RepeatReader is an io.Reader that repeats a given io.Reader
+// It is NOT safe to use a RepeatReader concurrently.
+type RepeatReader struct {
 	reader      io.Reader
 	readData    []byte
 	readIndex   int
@@ -17,7 +17,7 @@ type RepeaterReader struct {
 	repeatCount int
 }
 
-// NewRepeater creates RepeaterReader that will repeat the
+// NewRepeatReader creates RepeatReader that will repeat the
 // given reader "n" times. If n=0 it won't repeat it and will only
 // provide the contents of the given reader once. If n=1 it will repeat
 // once, duplicating the input.
@@ -27,14 +27,14 @@ type RepeaterReader struct {
 //
 // It can be a cheap way to generate gigantic inputs by repeating a very
 // small input.
-func NewRepeater(r io.Reader, n int) *RepeaterReader {
-	return &RepeaterReader{
+func NewRepeatReader(r io.Reader, n int) *RepeatReader {
+	return &RepeatReader{
 		reader:      r,
 		repeatCount: n,
 	}
 }
 
-func (r *RepeaterReader) Read(d []byte) (int, error) {
+func (r *RepeatReader) Read(d []byte) (int, error) {
 	if r.err == nil {
 		n, err := r.reader.Read(d)
 		r.err = err

--- a/iotest/iotest.go
+++ b/iotest/iotest.go
@@ -1,0 +1,21 @@
+// Package iotest implements io Read/Writers that are useful for testing.
+// It is inspired on the stdlib iotest: https://golang.org/pkg/testing/iotest/
+// It adds on it, instead of being a replacement.
+package iotest
+
+import "io"
+
+// RepeaterReader is an io.Reader that repeats a given io.Reader
+type RepeaterReader struct {
+}
+
+// NewRepeater creates RepeaterReader that will repeat the
+// given reader "n" times. If n is 0 it will repeat the
+// given stream forever (and infinite stream).
+func NewRepeater(r io.Reader, n uint) *RepeaterReader {
+	return nil
+}
+
+func (r *RepeaterReader) Read(d []byte) (int, error) {
+	return 0, nil
+}

--- a/iotest/iotest_bench_test.go
+++ b/iotest/iotest_bench_test.go
@@ -12,23 +12,23 @@ import (
 // different times and check that memory usage is constant (O(1))
 // regarding N (for N = amount of repetitions).
 
-func BenchmarkRepeat1(b *testing.B) {
+func BenchmarkRepeatReader1(b *testing.B) {
 	benchmarkRepeatReader(b, newInput(), 1)
 }
 
-func BenchmarkRepeat10(b *testing.B) {
+func BenchmarkRepeatReader10(b *testing.B) {
 	benchmarkRepeatReader(b, newInput(), 10)
 }
 
-func BenchmarkRepeat100(b *testing.B) {
+func BenchmarkRepeatReader100(b *testing.B) {
 	benchmarkRepeatReader(b, newInput(), 100)
 }
 
-func BenchmarkRepeat1000(b *testing.B) {
+func BenchmarkRepeatReader1000(b *testing.B) {
 	benchmarkRepeatReader(b, newInput(), 1000)
 }
 
-func BenchmarkRepeat10000(b *testing.B) {
+func BenchmarkRepeatReader10000(b *testing.B) {
 	benchmarkRepeatReader(b, newInput(), 10000)
 }
 

--- a/iotest/iotest_bench_test.go
+++ b/iotest/iotest_bench_test.go
@@ -3,7 +3,6 @@ package iotest_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/madlambda/spells/iotest"
@@ -11,7 +10,7 @@ import (
 
 // The core idea here is to repeat the same input
 // different times and check that memory usage is constant (O(1))
-// regarding N where N is amount of repetitions.
+// regarding N (for N = amount of repetitions).
 
 func BenchmarkRepeat1(b *testing.B) {
 	benchmarkRepeatReader(b, newInput(), 1)
@@ -29,13 +28,22 @@ func BenchmarkRepeat1000(b *testing.B) {
 	benchmarkRepeatReader(b, newInput(), 1000)
 }
 
+func BenchmarkRepeat10000(b *testing.B) {
+	benchmarkRepeatReader(b, newInput(), 10000)
+}
+
 func benchmarkRepeatReader(b *testing.B, input io.Reader, repeatCount int) {
+	data := make([]byte, 10)
+
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		repeater := iotest.NewRepeatReader(input, repeatCount)
-		_, err := ioutil.ReadAll(repeater)
-		if err != nil {
+		var err error
+		for err == nil {
+			_, err = repeater.Read(data)
+		}
+		if err != io.EOF {
 			b.Fatal(err)
 		}
 	}

--- a/iotest/iotest_bench_test.go
+++ b/iotest/iotest_bench_test.go
@@ -1,0 +1,46 @@
+package iotest_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/madlambda/spells/iotest"
+)
+
+// The core idea here is to repeat the same input
+// different times and check that memory usage is constant (O(1))
+// regarding N where N is amount of repetitions.
+
+func BenchmarkRepeat1(b *testing.B) {
+	benchmarkRepeatReader(b, newInput(), 1)
+}
+
+func BenchmarkRepeat10(b *testing.B) {
+	benchmarkRepeatReader(b, newInput(), 10)
+}
+
+func BenchmarkRepeat100(b *testing.B) {
+	benchmarkRepeatReader(b, newInput(), 100)
+}
+
+func BenchmarkRepeat1000(b *testing.B) {
+	benchmarkRepeatReader(b, newInput(), 1000)
+}
+
+func benchmarkRepeatReader(b *testing.B, input io.Reader, repeatCount int) {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		repeater := iotest.NewRepeatReader(input, repeatCount)
+		_, err := ioutil.ReadAll(repeater)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func newInput() *bytes.Buffer {
+	return bytes.NewBuffer([]byte("benchmarking is cool"))
+}

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/madlambda/spells/iotest"
 )
 
-// TODO: Test behavior with negative indexes
-
 func TestRepeatReader(t *testing.T) {
 
 	type Test struct {
@@ -68,6 +66,24 @@ func TestRepeatReader(t *testing.T) {
 
 			assertEqualText(t, got, test.want)
 		})
+	}
+}
+
+func TestPanicOnNegativeCount(t *testing.T) {
+	var panicErr interface{}
+	defer func() {
+		panicErr = recover()
+	}()
+
+	iotest.NewRepeatReader(bytes.NewBuffer([]byte("test")), -1)
+
+	if panicErr == nil {
+		t.Fatal("wanted panic, got nothing")
+	}
+
+	err := panicErr.(error)
+	if !errors.Is(err, iotest.RepeatReaderInvalidCount) {
+		t.Errorf("want '%v' got '%v'", iotest.RepeatReaderInvalidCount, err)
 	}
 }
 

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/madlambda/spells/iotest"
 )
 
+// TODO: Test behavior with negative indexes
+// Behavior could be:
+// - Just once, as 0
+// - Repeat forever...which may be useful and is not unheard off: https://pkg.go.dev/strings#SplitAfterN
+// - Panic, like: https://pkg.go.dev/strings#Repeat
+//
+// Overall, maybe it is best to keep same behavior as strings.Repeat (0 = none, 1 = repeat once).
+
 func TestRepeatReader(t *testing.T) {
 
 	type Test struct {
@@ -57,7 +65,7 @@ func TestRepeatReader(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			input := bytes.NewBuffer(test.data)
-			repeater := iotest.NewRepeater(input, test.repeat)
+			repeater := iotest.NewRepeatReader(input, test.repeat)
 
 			got, err := ioutil.ReadAll(repeater)
 			if err != nil {
@@ -72,7 +80,7 @@ func TestRepeatReader(t *testing.T) {
 func TestRepeatReaderReadBytePerByte(t *testing.T) {
 	inputData := []byte("bytePerByte")
 	want := append(inputData, inputData...)
-	repeater := iotest.NewRepeater(bytes.NewBuffer(inputData), 1)
+	repeater := iotest.NewRepeatReader(bytes.NewBuffer(inputData), 1)
 
 	got, err := ioutil.ReadAll(stdiotest.OneByteReader(repeater))
 	if err != nil {
@@ -91,7 +99,7 @@ func TestRepeatReaderCornerCasesOnUnderlyingReader(t *testing.T) {
 		t.Run(testname, func(t *testing.T) {
 			inputData := []byte("cornercases")
 			want := append(inputData, inputData...)
-			repeater := iotest.NewRepeater(newReader(bytes.NewBuffer(inputData)), 1)
+			repeater := iotest.NewRepeatReader(newReader(bytes.NewBuffer(inputData)), 1)
 
 			got, err := ioutil.ReadAll(repeater)
 			if err != nil {
@@ -104,7 +112,7 @@ func TestRepeatReaderCornerCasesOnUnderlyingReader(t *testing.T) {
 
 func TestRepeatReaderNonEOFErr(t *testing.T) {
 	want := errors.New("TestRepeatReaderNonEOFErr")
-	repeater := iotest.NewRepeater(stdiotest.ErrReader(want), 666)
+	repeater := iotest.NewRepeatReader(stdiotest.ErrReader(want), 666)
 	data := make([]byte, 10)
 
 	for i := 0; i < 10; i++ {

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -69,7 +69,19 @@ func TestRepeatReader(t *testing.T) {
 	}
 }
 
-func TestRepeatReaderCornerCases(t *testing.T) {
+func TestRepeatReaderReadBytePerByte(t *testing.T) {
+	inputData := []byte("bytePerByte")
+	want := append(inputData, inputData...)
+	repeater := iotest.NewRepeater(bytes.NewBuffer(inputData), 1)
+
+	got, err := ioutil.ReadAll(stdiotest.OneByteReader(repeater))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEqualText(t, got, want)
+}
+
+func TestRepeatReaderCornerCasesOnUnderlyingReader(t *testing.T) {
 	scenarios := map[string]func(io.Reader) io.Reader{
 		"SingleByteReading": stdiotest.OneByteReader,
 		"EOFWithData":       stdiotest.DataErrReader,
@@ -79,9 +91,9 @@ func TestRepeatReaderCornerCases(t *testing.T) {
 		t.Run(testname, func(t *testing.T) {
 			inputData := []byte("cornercases")
 			want := append(inputData, inputData...)
-			repeater := iotest.NewRepeater(bytes.NewBuffer(inputData), 1)
+			repeater := iotest.NewRepeater(newReader(bytes.NewBuffer(inputData)), 1)
 
-			got, err := ioutil.ReadAll(newReader(repeater))
+			got, err := ioutil.ReadAll(repeater)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -2,6 +2,7 @@ package iotest_test
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"testing"
 
@@ -66,21 +67,17 @@ func TestRepeatReader(t *testing.T) {
 }
 
 func TestRepeatReaderNonEOFErr(t *testing.T) {
-	repeater := iotest.NewRepeater(iotest.BrokenReader{}, 666)
+	want := errors.New("TestRepeatReaderNonEOFErr")
+	repeater := iotest.NewRepeater(iotest.BrokenReader{Err: want}, 666)
 	data := make([]byte, 10)
 
-	n, err := repeater.Read(data)
-	if n != 0 {
-		t.Errorf("got n=%d; want=0", n)
-	}
-	if err == nil {
-		t.Error("got nil error; want non-nil error")
-	}
-	n, err2 := repeater.Read(data)
-	if n != 0 {
-		t.Errorf("got n=%d; want=0", n)
-	}
-	if err != err2 {
-		t.Errorf("got error: %v; want error: %v", err2, err)
+	for i := 0; i < 10; i++ {
+		n, err := repeater.Read(data)
+		if n != 0 {
+			t.Errorf("got n=%d; want=0", n)
+		}
+		if err != want {
+			t.Errorf("got %v; want %v", err, want)
+		}
 	}
 }

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -17,7 +17,7 @@ func TestRepeatReader(t *testing.T) {
 	type Test struct {
 		name   string
 		data   []byte
-		repeat uint
+		repeat int
 		want   []byte
 	}
 

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -18,7 +18,7 @@ import (
 // - Repeat forever...which may be useful and is not unheard off: https://pkg.go.dev/strings#SplitAfterN
 // - Panic, like: https://pkg.go.dev/strings#Repeat
 //
-// Overall, maybe it is best to keep same behavior as strings.Repeat (0 = none, 1 = repeat once).
+// Overall, maybe it is best to keep same behavior as strings.Repeat (-1 = panic, 0 = none, 1 = repeat once).
 
 func TestRepeatReader(t *testing.T) {
 

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -1,0 +1,44 @@
+package iotest_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/madlambda/spells/iotest"
+)
+
+func TestRepeatReader(t *testing.T) {
+
+	type Test struct {
+		data   []byte
+		repeat uint
+		want   []byte
+	}
+
+	tests := []Test{
+		{
+			data:   []byte("test"),
+			repeat: 1,
+			want:   []byte("test"),
+		},
+	}
+
+	for _, test := range tests {
+		input := bytes.NewBuffer(test.data)
+		repeater := iotest.NewRepeater(input, test.repeat)
+
+		got, err := ioutil.ReadAll(repeater)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// WHY: we usually test with text
+		gotstr := string(got)
+		wantstr := string(test.want)
+
+		if gotstr != wantstr {
+			t.Fatalf("got %q; want %q", gotstr, wantstr)
+		}
+	}
+}

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -11,6 +11,7 @@ import (
 func TestRepeatReader(t *testing.T) {
 
 	type Test struct {
+		name   string
 		data   []byte
 		repeat uint
 		want   []byte
@@ -18,27 +19,48 @@ func TestRepeatReader(t *testing.T) {
 
 	tests := []Test{
 		{
+			name:   "NoRepeat",
+			data:   []byte("test"),
+			repeat: 0,
+			want:   []byte("test"),
+		},
+		{
+			name:   "RepeatOnce",
 			data:   []byte("test"),
 			repeat: 1,
-			want:   []byte("test"),
+			want:   []byte("testtest"),
+		},
+		{
+			name:   "RepeatTwice",
+			data:   []byte("test"),
+			repeat: 2,
+			want:   []byte("testtesttest"),
+		},
+		{
+			name:   "RepeatSingleByte",
+			data:   []byte("t"),
+			repeat: 1,
+			want:   []byte("tt"),
 		},
 	}
 
 	for _, test := range tests {
-		input := bytes.NewBuffer(test.data)
-		repeater := iotest.NewRepeater(input, test.repeat)
+		t.Run(test.name, func(t *testing.T) {
+			input := bytes.NewBuffer(test.data)
+			repeater := iotest.NewRepeater(input, test.repeat)
 
-		got, err := ioutil.ReadAll(repeater)
-		if err != nil {
-			t.Fatal(err)
-		}
+			got, err := ioutil.ReadAll(repeater)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		// WHY: we usually test with text
-		gotstr := string(got)
-		wantstr := string(test.want)
+			// WHY: we usually test with text
+			gotstr := string(got)
+			wantstr := string(test.want)
 
-		if gotstr != wantstr {
-			t.Fatalf("got %q; want %q", gotstr, wantstr)
-		}
+			if gotstr != wantstr {
+				t.Fatalf("got %q; want %q", gotstr, wantstr)
+			}
+		})
 	}
 }

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -64,3 +64,23 @@ func TestRepeatReader(t *testing.T) {
 		})
 	}
 }
+
+func TestRepeatReaderNonEOFErr(t *testing.T) {
+	repeater := iotest.NewRepeater(iotest.BrokenReader{}, 666)
+	data := make([]byte, 10)
+
+	n, err := repeater.Read(data)
+	if n != 0 {
+		t.Errorf("got n=%d; want=0", n)
+	}
+	if err == nil {
+		t.Error("got nil error; want non-nil error")
+	}
+	n, err2 := repeater.Read(data)
+	if n != 0 {
+		t.Errorf("got n=%d; want=0", n)
+	}
+	if err != err2 {
+		t.Errorf("got error: %v; want error: %v", err2, err)
+	}
+}

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -104,7 +104,7 @@ func TestRepeatReaderCornerCasesOnUnderlyingReader(t *testing.T) {
 
 func TestRepeatReaderNonEOFErr(t *testing.T) {
 	want := errors.New("TestRepeatReaderNonEOFErr")
-	repeater := iotest.NewRepeater(iotest.BrokenReader{Err: want}, 666)
+	repeater := iotest.NewRepeater(stdiotest.ErrReader(want), 666)
 	data := make([]byte, 10)
 
 	for i := 0; i < 10; i++ {

--- a/iotest/iotest_test.go
+++ b/iotest/iotest_test.go
@@ -82,8 +82,8 @@ func TestPanicOnNegativeCount(t *testing.T) {
 	}
 
 	err := panicErr.(error)
-	if !errors.Is(err, iotest.RepeatReaderInvalidCount) {
-		t.Errorf("want '%v' got '%v'", iotest.RepeatReaderInvalidCount, err)
+	if !errors.Is(err, iotest.RepeatReaderInvalidCountErr) {
+		t.Errorf("want '%v' got '%v'", iotest.RepeatReaderInvalidCountErr, err)
 	}
 }
 


### PR DESCRIPTION
Add a repeater reader. I intend to use the repeater to benchmark some code and I want to inject a long stream, so just repeating the same initial data multiple times seem like a reasonable way to achieve that, given that I don't want the space complexity to be O(N) where N = total size of the stream, I want N = size of the initial repeated message (which can be small, effectively making it O(1) with regard to the size of the stream itself).

To be more concrete, will start using this on jtoh: https://github.com/katcipis/jtoh
So I can test its behavior/bench-marking with arbitrarily long streams but checking that memory usage is O(1) (constant usage, not increasing with stream size).

Benchmark results:

```sh
make bench/memory/iotest
go test -bench=. -benchmem -memprofile="profilling/iotest-memory.p" "./iotest"
goos: linux
goarch: amd64
pkg: github.com/madlambda/spells/iotest
cpu: Intel(R) Core(TM) i5-8600K CPU @ 3.60GHz
BenchmarkRepeatReader1-6        58873488                19.78 ns/op            0 B/op          0 allocs/op
BenchmarkRepeatReader10-6       12692946                94.00 ns/op            0 B/op          0 allocs/op
BenchmarkRepeatReader100-6       1576902               764.1 ns/op             0 B/op          0 allocs/op
BenchmarkRepeatReader1000-6       159327              7445 ns/op               0 B/op          0 allocs/op
BenchmarkRepeatReader10000-6       16159             74371 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/madlambda/spells/iotest      7.673s
```

Inspired on the stdlib [iotest](https://golang.org/pkg/testing/iotest).