### PR TITLE
feat: add initial errutils.Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@
 [![Build Status](https://travis-ci.org/madlambda/spells.svg?branch=master)](https://travis-ci.org/madlambda/spells)
 [![Go Report Card](https://goreportcard.com/badge/github.com/madlambda/spells)](https://goreportcard.com/report/github.com/madlambda/spells)
 
-Small and usefull Go functions
+Small and (hopefully) useful set of Go functions.
+The idea is to extend what we can't find on Go's stdlib
+with the simplest approach possible.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # spells
 
 [![GoDoc](https://godoc.org/github.com/madlambda/spells?status.svg)](https://godoc.org/github.com/madlambda/spells)
-[![Build Status](https://travis-ci.org/madlambda/spells.svg?branch=master)](https://travis-ci.org/madlambda/spells)
+[![Static Analysis Status](https://github.com/madlambda/spells/actions/workflows/lint.yml/badge.svg)[![Test Status](https://github.com/madlambda/spells/actions/workflows/test.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/madlambda/spells)](https://goreportcard.com/report/github.com/madlambda/spells)
 
 Small and (hopefully) useful set of Go functions.

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -7,8 +7,13 @@
 // - Improved chaining of error sentinels (wrapping multiple errors).
 package errutil
 
+// Error implements the Go's error interface in the simplest
+// way possible, allowing initialization error sentinels to be done
+// at compile time as constants. It does so by using a string
+// as it's base type.
 type Error string
 
+// Error return a string representation of the error.
 func (e Error) Error() string {
 	return string(e)
 }

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -4,7 +4,6 @@
 // Utilities include:
 //
 // - An error type that makes it easy to work with const error sentinels.
-// - Improved chaining of error sentinels (wrapping multiple errors).
 package errutil
 
 // Error implements the Go's error interface in the simplest

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -1,0 +1,14 @@
+// Package errutil implements some useful extensions to the stdlib
+// Go errors package, in the same spirit of packages like ioutil/httputil.
+//
+// Utilities include:
+//
+// - An error type that makes it easy to work with const error sentinels.
+// - Improved chaining of error sentinels (wrapping multiple errors).
+package errutil
+
+type Error string
+
+func (e Error) Error() string {
+	return string(e)
+}

--- a/errutil/error_example_test.go
+++ b/errutil/error_example_test.go
@@ -1,0 +1,24 @@
+package errutil_test
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/madlambda/spells/errutil"
+)
+
+func ExampleError() {
+	// Declare your error sentinels using errutil.Error
+	const (
+		someError errutil.Error = "someError"
+	)
+
+	// You add some context to the sentinel error
+	wrappedErr := fmt.Errorf("wrapping up: %w", someError)
+
+	// Checking programmatically for the underlying error
+	// Users of your API handle the sentinel opaquely
+	fmt.Println(errors.Is(wrappedErr, someError))
+
+	// Output: true
+}

--- a/errutil/error_test.go
+++ b/errutil/error_test.go
@@ -1,0 +1,42 @@
+package errutil_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/madlambda/spells/errutil"
+)
+
+func TestErrorSentinelWrapping(t *testing.T) {
+	const (
+		someError        errutil.Error = "someError"
+		someAnotherError errutil.Error = "someAnotherError"
+	)
+
+	wrappedErr := fmt.Errorf("wrapping up: %w", someError)
+	assertErrorIsWrapped(t, wrappedErr, someError)
+
+	wrappedErr2 := fmt.Errorf("wrapping up: %w", someAnotherError)
+	assertErrorIsWrapped(t, wrappedErr2, someAnotherError)
+}
+
+func TestErrorRepresentation(t *testing.T) {
+	const (
+		someError errutil.Error = "someError"
+	)
+
+	got := someError.Error()
+	want := string(someError)
+
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func assertErrorIsWrapped(t *testing.T, err error, target error) {
+	t.Helper()
+	if !errors.Is(err, target) {
+		t.Errorf("error [%v] is not wrapping [%v]", err, target)
+	}
+}


### PR DESCRIPTION
The idea is to have on a first PR just the basic error sentinel implementation. I'm not sure if we should have errutil.Error or maybe errutil.Sentinel, started to think that maybe in the future we could have more sophisticated general purpose error types, inspired by some things on the upspin error handling, and then this very simple one would be suitable for simple situations where just a sentinel is enough (hence the name Sentinel). 

The main issue with the very simple sentinel is that to make it initializable as a const, it needs to have an basic/const underlying type like string/int, so we need to leak that on the type definition. Another error type that is just a struct {} with unexported fields would allow us to change the internal representation of the type without breaking anyone, extending it, adding features, etc. 

But not sure, WDYT @i4ki @vitorarins ?