### PR TITLE
feat: errutil.Reduce

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
+coverage=coverage.txt
+
 all: lint test bench
 
 test:
-	go test -race -timeout 10s -coverprofile=coverage.txt -covermode=atomic ./...
+	go test -race -timeout 10s -coverprofile=$(coverage) -covermode=atomic ./...
 
 test/%:
-	go test -race -timeout 10s -coverprofile=coverage.txt -covermode=atomic -run="${*}" ./...
+	go test -race -timeout 10s -coverprofile=$(coverage) -covermode=atomic -run="${*}" ./...
+
+coverage/show: test
+	go tool cover -html=$(coverage)
 
 fmt:
 	gofmt -s -w .

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -48,6 +48,23 @@ func Chain(errs ...error) error {
 	}
 }
 
+// Merge reduces all given errors to a single opaque error
+// instance containing the original information from all
+// errors aggregated but in an opaque way (opposed to Chain).
+//
+// If the len(errs) == 0 it returns nil, if len(errs) == 1 it
+// returns the error itself and it will filter out nil errs.
+//
+// It is specially useful to manage lists of errors and
+// return an error only if any of the errors failed.
+func Merge(errs ...error) error {
+	return Reduce(func(err1, err2 error) error {
+		// TODO: add nil filtering
+
+		return errors.New(err1.Error() + ": " + err2.Error())
+	}, errs...)
+}
+
 // Reduce will reduce all errors to a single one using the
 // provided reduce function.
 //

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -50,6 +50,14 @@ func Chain(errs ...error) error {
 
 // Reduce will reduce all errors to a single one using the
 // provided reduce function.
+//
+// If errs is empty it returns nil, if errs has a single err
+// (len(errs) == 1) it will return the err itself.
+//
+// It won't assume anything else about the given errs, always
+// calling the reduce function, so nil errs on will be passed
+// to the reduce function so it can deal with them.
+//
 // Reduce will panic if the given reduce function panics.
 func Reduce(reduce Reducer, errs ...error) error {
 	if len(errs) == 0 {

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -4,6 +4,11 @@
 // Utilities include:
 //
 // - An error type that makes it easy to work with const error sentinels.
+// - An easy way to wrap a list of errors together.
+// - An easy way to merge a list of errors opaquely.
+//
+// Flexible enough that you can do your own wrapping/merging logic
+// but in a functional/simple way.
 package errutil
 
 import "errors"
@@ -13,6 +18,9 @@ import "errors"
 // at compile time as constants. It does so by using a string
 // as it's base type.
 type Error string
+
+// Reducer reduces 2 errors into one
+type Reducer func(error, error) error
 
 // Error return a string representation of the error.
 func (e Error) Error() string {
@@ -38,6 +46,13 @@ func Chain(errs ...error) error {
 		head: errs[0],
 		tail: Chain(errs[1:]...),
 	}
+}
+
+// Reduce will reduce all errors to a single one using the
+// provided reduce function.
+// Reduce will panic if the given reduce function panics.
+func Reduce(reduce Reducer, errs ...error) error {
+	return nil
 }
 
 type errorChain struct {

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -48,30 +48,6 @@ func Chain(errs ...error) error {
 	}
 }
 
-// Merge reduces all given errors to a single opaque error
-// instance containing the original information from all
-// errors aggregated but in an opaque way (opposed to Chain).
-//
-// If the len(errs) == 0 it returns nil, if len(errs) == 1 it
-// returns the error itself and it will filter out nil errs.
-//
-// It is specially useful to manage lists of errors and
-// return an error only if any of the errors failed.
-func Merge(errs ...error) error {
-	return Reduce(func(err1, err2 error) error {
-		if err1 == nil && err2 == nil {
-			return nil
-		}
-		if err1 == nil {
-			return err2
-		}
-		if err2 == nil {
-			return err1
-		}
-		return errors.New(err1.Error() + ": " + err2.Error())
-	}, errs...)
-}
-
 // Reduce will reduce all errors to a single one using the
 // provided reduce function.
 //
@@ -82,6 +58,8 @@ func Merge(errs ...error) error {
 // calling the reduce function, so nil errs on will be passed
 // to the reduce function so it can deal with them.
 func Reduce(reduce Reducer, errs ...error) error {
+	errs = removeNils(errs)
+
 	if len(errs) == 0 {
 		return nil
 	}

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -5,7 +5,7 @@
 //
 // - An error type that makes it easy to work with const error sentinels.
 // - An easy way to wrap a list of errors together.
-// - An easy way to merge a list of errors opaquely.
+// - An easy way to reduce a list of errors.
 //
 // Flexible enough that you can do your own wrapping/merging logic
 // but in a functional/simple way.

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -81,8 +81,6 @@ func Merge(errs ...error) error {
 // It won't assume anything else about the given errs, always
 // calling the reduce function, so nil errs on will be passed
 // to the reduce function so it can deal with them.
-//
-// Reduce will panic if the given reduce function panics.
 func Reduce(reduce Reducer, errs ...error) error {
 	if len(errs) == 0 {
 		return nil

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -52,7 +52,15 @@ func Chain(errs ...error) error {
 // provided reduce function.
 // Reduce will panic if the given reduce function panics.
 func Reduce(reduce Reducer, errs ...error) error {
-	return nil
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	err1, err2 := errs[0], errs[1]
+	err := reduce(err1, err2)
+	return Reduce(reduce, append([]error{err}, errs[2:]...)...)
 }
 
 type errorChain struct {

--- a/errutil/error.go
+++ b/errutil/error.go
@@ -59,8 +59,15 @@ func Chain(errs ...error) error {
 // return an error only if any of the errors failed.
 func Merge(errs ...error) error {
 	return Reduce(func(err1, err2 error) error {
-		// TODO: add nil filtering
-
+		if err1 == nil && err2 == nil {
+			return nil
+		}
+		if err1 == nil {
+			return err2
+		}
+		if err2 == nil {
+			return err1
+		}
 		return errors.New(err1.Error() + ": " + err2.Error())
 	}, errs...)
 }

--- a/errutil/error_example_test.go
+++ b/errutil/error_example_test.go
@@ -48,7 +48,7 @@ func ExampleChain() {
 	// layer1Err: layer2Err: layer3Err
 }
 
-func ExampleMerge() {
+func ExampleReduce() {
 	// call multiple functions that may return an error
 	// but none of them should interrupt overall computation
 	var i int
@@ -63,9 +63,12 @@ func ExampleMerge() {
 	errs = append(errs, someFunc())
 	errs = append(errs, someFunc())
 
-	err := errutil.Merge(errs...)
+	err := errutil.Reduce(func(err1, err2 error) error {
+		return fmt.Errorf("%v,%v", err1, err2)
+	}, errs...)
+
 	fmt.Println(err)
 
 	// Output:
-	// error 1: error 2: error 3
+	// error 1,error 2,error 3
 }

--- a/errutil/error_example_test.go
+++ b/errutil/error_example_test.go
@@ -63,11 +63,7 @@ func ExampleMerge() {
 	errs = append(errs, someFunc())
 	errs = append(errs, someFunc())
 
-	// Chain the errors
 	err := errutil.Merge(errs...)
-
-	// Checking programmatically for the underlying error
-	// Users of your API handle the sentinels opaquely
 	fmt.Println(err)
 
 	// Output:

--- a/errutil/error_example_test.go
+++ b/errutil/error_example_test.go
@@ -39,9 +39,37 @@ func ExampleChain() {
 	fmt.Println(errors.Is(err, layer1Err))
 	fmt.Println(errors.Is(err, layer2Err))
 	fmt.Println(errors.Is(err, layer3Err))
+	fmt.Println(err)
 
 	// Output:
 	// true
 	// true
 	// true
+	// layer1Err: layer2Err: layer3Err
+}
+
+func ExampleMerge() {
+	// call multiple functions that may return an error
+	// but none of them should interrupt overall computation
+	var i int
+	someFunc := func() error {
+		i++
+		return fmt.Errorf("error %d", i)
+	}
+
+	var errs []error
+
+	errs = append(errs, someFunc())
+	errs = append(errs, someFunc())
+	errs = append(errs, someFunc())
+
+	// Chain the errors
+	err := errutil.Merge(errs...)
+
+	// Checking programmatically for the underlying error
+	// Users of your API handle the sentinels opaquely
+	fmt.Println(err)
+
+	// Output:
+	// error 1: error 2: error 3
 }

--- a/errutil/error_test.go
+++ b/errutil/error_test.go
@@ -266,10 +266,20 @@ func TestErrorReducing(t *testing.T) {
 
 	tests := []testcase{
 		{
-			name:   "reducing one error",
-			errs:   []error{errors.New("one")},
-			reduce: mergeWithComma,
-			want:   "one",
+			name: "reducing empty err list wont call reducer and returns nil",
+			errs: []error{},
+			reduce: func(err1, err2 error) error {
+				panic("unreachable")
+			},
+			wantNil: true,
+		},
+		{
+			name: "reducing one error wont call reducer and returns error",
+			errs: []error{errors.New("one")},
+			reduce: func(err1, err2 error) error {
+				panic("should not be called")
+			},
+			want: "one",
 		},
 		{
 			name:   "reducing two errors",
@@ -339,22 +349,6 @@ func TestErrorReducing(t *testing.T) {
 			},
 			reduce: func(err1, err2 error) error {
 				return nil
-			},
-			wantNil: true,
-		},
-		{
-			name: "reduces single err to nil",
-			errs: []error{errors.New("one")},
-			reduce: func(err1, err2 error) error {
-				return nil
-			},
-			wantNil: true,
-		},
-		{
-			name: "reduces empty err list to nil",
-			errs: []error{},
-			reduce: func(err1, err2 error) error {
-				panic("unreachable")
 			},
 			wantNil: true,
 		},

--- a/errutil/error_test.go
+++ b/errutil/error_test.go
@@ -289,6 +289,55 @@ func TestErrorReducing(t *testing.T) {
 	}
 }
 
+func TestErrorMerging(t *testing.T) {
+	type TestCase struct {
+		name string
+		errs []error
+		want string
+	}
+
+	tcases := []TestCase{
+		{
+			name: "Two Merged Errors",
+			errs: []error{
+				errors.New("error 1"),
+				errors.New("error 2"),
+			},
+			want: "error 1: error 2",
+		},
+		{
+			name: "Three Merged Errors",
+			errs: []error{
+				errors.New("error 1"),
+				errors.New("error 2"),
+				errors.New("error 3"),
+			},
+			want: "error 1: error 2: error 3",
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			err := errutil.Merge(tc.errs...)
+			assert.Error(t, err)
+
+			got := err.Error()
+
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+
+			for _, inputErr := range tc.errs {
+				if errors.Is(err, inputErr) {
+					t.Fatalf("errors.Is(%q, %q)=true; want false", err, inputErr)
+				}
+			}
+		})
+	}
+
+}
+
 // To test the Is method the error must not be comparable.
 // If it is comparable, Go always just compares it, the Is method
 // is just a fallback, not an override of actual behavior.

--- a/errutil/error_test.go
+++ b/errutil/error_test.go
@@ -342,7 +342,7 @@ func TestErrorMerging(t *testing.T) {
 			want: "error 1: error 2",
 		},
 		{
-			name: "multiple nils",
+			name: "multiple nils interleaved",
 			errs: []error{
 				nil,
 				nil,
@@ -378,6 +378,21 @@ func TestErrorMerging(t *testing.T) {
 		})
 	}
 
+}
+
+func TestErrorMergingSingleErrorReturnItself(t *testing.T) {
+	want := errors.New("some err")
+	got := errutil.Merge(want)
+	if got != want {
+		t.Fatalf("errutil.Merge(%v)=%v; want=%v", want, got, want)
+	}
+}
+
+func TestErrorMergingOnlyNilReturnsNil(t *testing.T) {
+	assert.NoError(t, errutil.Merge())
+	assert.NoError(t, errutil.Merge(nil))
+	assert.NoError(t, errutil.Merge(nil, nil))
+	assert.NoError(t, errutil.Merge(nil, nil, nil))
 }
 
 // To test the Is method the error must not be comparable.

--- a/errutil/error_test.go
+++ b/errutil/error_test.go
@@ -298,7 +298,7 @@ func TestErrorMerging(t *testing.T) {
 
 	tcases := []TestCase{
 		{
-			name: "Two Merged Errors",
+			name: "two merged errors",
 			errs: []error{
 				errors.New("error 1"),
 				errors.New("error 2"),
@@ -306,13 +306,55 @@ func TestErrorMerging(t *testing.T) {
 			want: "error 1: error 2",
 		},
 		{
-			name: "Three Merged Errors",
+			name: "three merged errors",
 			errs: []error{
 				errors.New("error 1"),
 				errors.New("error 2"),
 				errors.New("error 3"),
 			},
 			want: "error 1: error 2: error 3",
+		},
+		{
+			name: "first is nil",
+			errs: []error{
+				nil,
+				errors.New("error 2"),
+				errors.New("error 3"),
+			},
+			want: "error 2: error 3",
+		},
+		{
+			name: "second is nil",
+			errs: []error{
+				errors.New("error 1"),
+				nil,
+				errors.New("error 3"),
+			},
+			want: "error 1: error 3",
+		},
+		{
+			name: "third is nil",
+			errs: []error{
+				errors.New("error 1"),
+				errors.New("error 2"),
+				nil,
+			},
+			want: "error 1: error 2",
+		},
+		{
+			name: "multiple nils",
+			errs: []error{
+				nil,
+				nil,
+				nil,
+				errors.New("error 1"),
+				nil,
+				nil,
+				errors.New("error 2"),
+				nil,
+				nil,
+			},
+			want: "error 1: error 2",
 		},
 	}
 

--- a/errutil/error_test.go
+++ b/errutil/error_test.go
@@ -470,9 +470,9 @@ func TestErrorReducing(t *testing.T) {
 	}
 }
 
-// To test the Is method the error must not be comparable.
+// To test the Is method the error base type must not be comparable.
 // If it is comparable, Go always just compares it, the Is method
-// is just a fallback, not an override of actual behavior.
+// is just a fallback, not an override of actual comparison behavior.
 type errorThatNeverIs []string
 
 func (e errorThatNeverIs) Is(err error) bool {

--- a/errutil/error_test.go
+++ b/errutil/error_test.go
@@ -256,13 +256,14 @@ func TestErrorReducing(t *testing.T) {
 			g := errutil.Reduce(test.reduce, test.input...)
 
 			if test.want == nil {
-				if g != nil {
-					t.Fatalf(
-						"errutil.Reduce(%v)=%q; want nil",
-						test.input,
-						g,
-					)
+				if g == nil {
+					return
 				}
+				t.Fatalf(
+					"errutil.Reduce(%v)=%q; want nil",
+					test.input,
+					g,
+				)
 			}
 
 			if g == nil {

--- a/errutil/error_test.go
+++ b/errutil/error_test.go
@@ -245,7 +245,6 @@ func TestErrorReducing(t *testing.T) {
 			input: []error{},
 			reduce: func(err1, err2 error) error {
 				panic("unreachable")
-				return nil
 			},
 			want: nil,
 		},


### PR DESCRIPTION
I started thinking just on Merge and an easy way to deal with slices of errors, where we accumulate a bunch of errors and want to merge all them together or return nil if no error happened, as easily as possible. But one thing that annoys me is how we usually hardcode the formatting (we also do it on chain), but it is hard to come up with something that is flexible on formatting that is not more verbose, like having error list handlers, chain handlers, objects, etc. Wanted to keep everything as simple functions operating on the core error type. The less terrible way I could imagine is the errutil.Reduce idea, because it seems to be what we are doing with the errors on merge (reducing a set to a single value, accumulating..in a way).

Not sure the idea is good, just the first one I had to keep things reasonably simple and non-intrusive (no need to use special types, just Go's error). The reduce implementation is quite trivial but maybe inneficient on its use of recursion, but that can be changed later, I wanted to focus on the published API itself, if it makes sense or not.

We decided to go for automatic nil filtering, which I think makes it much easier/safer to use, but it does introduce an oddity when the reducer itself returns nil. I was in doubt but in the end decided that returned nils are not filtered...but I'm not sure, the test that was failing and I was puzzled with is this one:

```go
		{
			name: "reduces 3 errs to nil",
			errs: []error{
				errors.New("one"),
				errors.New("two"),
				errors.New("three"),
			},
			reduce: func(err1, err2 error) error {
				return nil
			},
			wantNil: true,
		},
```

If we filter nils that is not possible, since after reducing 2 errs to nil, if that nil is filtered out, then a single parameter on reduce always return itself (nothing to reduce), so this would fail...but if felt counter intuitive...but Im not sure... :thinking: 